### PR TITLE
Improve forgot password error diagnostics

### DIFF
--- a/SmartHR/src/pages/auth/forgetPassword/ForgetPassword.js
+++ b/SmartHR/src/pages/auth/forgetPassword/ForgetPassword.js
@@ -57,7 +57,23 @@ const ForgetPassword = (props) => {
         showSuccess(response.data.message)
       }
     } catch (err) {
-      showError(err.data.message)
+      const responseData = err?.response?.data
+      let message = ''
+
+      if (responseData) {
+        if (typeof responseData === 'string') {
+          message = responseData
+        } else if (typeof responseData?.message === 'string') {
+          message = responseData.message
+        }
+      }
+
+      if (!message) {
+        message = err?.message || 'An unexpected error occurred.'
+        console.error('Unexpected error shape in ForgetPassword:', err)
+      }
+
+      showError(message)
     } finally {
       setIsLoading(false) // Kết thúc tải sau khi hoàn thành API call
     }


### PR DESCRIPTION
## Summary
- extract error messages from the forgot password API response before showing a notification
- fall back to generic error messaging and log unexpected response shapes for diagnostics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cd35b50b388323bbd8a7572d40ec55