### PR TITLE
Ensure OKR detail pane stretches full viewport height

### DIFF
--- a/SmartHR/src/App.css
+++ b/SmartHR/src/App.css
@@ -25,5 +25,7 @@ html, body, #root { height: 100%; }
   flex: 1;
   min-height: 0;          /* QUAN TRỌNG */
   overflow: hidden;       /* ag-grid & sidepane tự scroll */
-  margin: 5px 10px;
+  margin: 0;
+  padding: 5px 10px;
+  box-sizing: border-box; /* giữ khoảng cách nhưng vẫn full-height */
 }

--- a/SmartHR/src/components/sidepane/okrDetailSidePane.js
+++ b/SmartHR/src/components/sidepane/okrDetailSidePane.js
@@ -10,14 +10,21 @@ const OkrDetailSidePane = ({ open, onClose, data }) => {
       onClose={onClose}
       keepMounted
       PaperProps={{
-        sx: { width: { xs: '100%', md: 720 }, borderRadius: '12px 0 0 12px' }
+        sx: {
+          width: { xs: '100%', md: 720 },
+          borderRadius: { xs: 0, md: '12px 0 0 12px' },
+          height: '100dvh',
+          maxHeight: '100dvh',
+          display: 'flex',
+          flexDirection: 'column'
+        }
       }}
     >
-      <Box sx={{ height: '100%', overflowY: 'auto' }}>
+      <Box sx={{ flex: 1, overflowY: 'auto' }}>
         <OkrDetail data={data} />
       </Box>
     </Drawer>
-    
+
   )
 }
 

--- a/SmartHR/src/pages/okr/okrTab/OkrTab.js
+++ b/SmartHR/src/pages/okr/okrTab/OkrTab.js
@@ -590,7 +590,12 @@ const OkrTab = forwardRef(
     return (
       <Paper
         elevation={0}
-        sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}
+        sx={{
+          height: '100%',
+          minHeight: 0,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
       >
         <Box
           sx={{


### PR DESCRIPTION
## Summary
- style the OKR detail drawer paper to use the dynamic viewport height and flex layout so its contents fill the panel
- remove the router margin in favor of padding so routed pages can occupy the full height while keeping spacing
- let the OKR tab container flex to the available height instead of forcing a fixed viewport height

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_b_68cd366780cc8323b838da9ff1d15968